### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/markausten/4177f046-bc87-4283-9803-16f8e5ab587c/bb1cd58a-c041-40ed-93d3-d569b6d45d73/_apis/work/boardbadge/de18a9a0-4d12-4b7c-a176-5e1e2c97f5ac)](https://dev.azure.com/markausten/4177f046-bc87-4283-9803-16f8e5ab587c/_boards/board/t/bb1cd58a-c041-40ed-93d3-d569b6d45d73/Microsoft.RequirementCategory)
 # Powerbi-samples
 Powerbi-developer-samples


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/markausten/4177f046-bc87-4283-9803-16f8e5ab587c/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.